### PR TITLE
Added new trait for any calls not covered by code

### DIFF
--- a/src/Brightree/Services/CustomFieldService.php
+++ b/src/Brightree/Services/CustomFieldService.php
@@ -14,4 +14,9 @@ class CustomFieldService {
   public function CustomFieldValueSaveMultiple($category,$brightreeID,$fieldValues) {
     return $this->ApiCall('CustomFieldValueSaveMultiple', ['category' => $category, 'brightreeID' => $brightreeID, 'fieldValues' => $fieldValues]);
   }
+
+  public function Custom($method, $customInformation)
+  {
+    return $this->ApiCall($method, $customInformation);
+  }
 }

--- a/src/Brightree/Services/CustomFieldService.php
+++ b/src/Brightree/Services/CustomFieldService.php
@@ -7,7 +7,6 @@ class CustomFieldService {
   use \Brightree\Traits\ApiTrait;
   use \Brightree\Traits\CustomTrait;
 
-
   public function __construct($params) {
     $this->params = $params;
     $this->wsdl_path = "https://webservices.brightree.net/v0100-1610/CustomFieldService/CustomFieldService.svc?singleWsdl";
@@ -16,5 +15,4 @@ class CustomFieldService {
   public function CustomFieldValueSaveMultiple($category,$brightreeID,$fieldValues) {
     return $this->ApiCall('CustomFieldValueSaveMultiple', ['category' => $category, 'brightreeID' => $brightreeID, 'fieldValues' => $fieldValues]);
   }
-
 }

--- a/src/Brightree/Services/CustomFieldService.php
+++ b/src/Brightree/Services/CustomFieldService.php
@@ -5,6 +5,8 @@ namespace Brightree\Services;
 class CustomFieldService {
 
   use \Brightree\Traits\ApiTrait;
+  use \Brightree\Traits\CustomTrait;
+
 
   public function __construct($params) {
     $this->params = $params;
@@ -15,8 +17,4 @@ class CustomFieldService {
     return $this->ApiCall('CustomFieldValueSaveMultiple', ['category' => $category, 'brightreeID' => $brightreeID, 'fieldValues' => $fieldValues]);
   }
 
-  public function Custom($method, $customInformation)
-  {
-    return $this->ApiCall($method, $customInformation);
-  }
 }

--- a/src/Brightree/Services/DoctorService.php
+++ b/src/Brightree/Services/DoctorService.php
@@ -5,6 +5,8 @@ namespace Brightree\Services;
 class DoctorService {
 
   use \Brightree\Traits\ApiTrait;
+  use \Brightree\Traits\CustomTrait;
+
 
   public function __construct($params) {
     $this->params = $params;
@@ -15,8 +17,4 @@ class DoctorService {
     return $this->ApiCall('DoctorCreate', ['Doctor' => $doctor]);
   }
 
-  public function Custom($method, $doctorInformation)
-  {
-    return $this->ApiCall($method, $doctorInformation);
-  }
 }

--- a/src/Brightree/Services/DoctorService.php
+++ b/src/Brightree/Services/DoctorService.php
@@ -7,7 +7,6 @@ class DoctorService {
   use \Brightree\Traits\ApiTrait;
   use \Brightree\Traits\CustomTrait;
 
-
   public function __construct($params) {
     $this->params = $params;
     $this->wsdl_path = "https://webservices.brightree.net/v0100-2008/DoctorService/DoctorService.svc?singleWsdl";
@@ -16,5 +15,4 @@ class DoctorService {
   public function DoctorCreate($doctor) {
     return $this->ApiCall('DoctorCreate', ['Doctor' => $doctor]);
   }
-
 }

--- a/src/Brightree/Services/DoctorService.php
+++ b/src/Brightree/Services/DoctorService.php
@@ -14,4 +14,9 @@ class DoctorService {
   public function DoctorCreate($doctor) {
     return $this->ApiCall('DoctorCreate', ['Doctor' => $doctor]);
   }
+
+  public function Custom($method, $doctorInformation)
+  {
+    return $this->ApiCall($method, $doctorInformation);
+  }
 }

--- a/src/Brightree/Services/DocumentManagementService.php
+++ b/src/Brightree/Services/DocumentManagementService.php
@@ -45,4 +45,9 @@ class DocumentManagementService{
       'FileContents' => $FileContents
       ]);
   }
+
+  public function Custom($method, $documentInformation)
+  {
+    return $this->ApiCall($method, $documentInformation);
+  }
 }

--- a/src/Brightree/Services/DocumentManagementService.php
+++ b/src/Brightree/Services/DocumentManagementService.php
@@ -5,6 +5,8 @@ namespace Brightree\Services;
 class DocumentManagementService{
 
   use \Brightree\Traits\ApiTrait;
+  use \Brightree\Traits\CustomTrait;
+
 
   public function __construct($params) {
     $this->params = $params;
@@ -46,8 +48,4 @@ class DocumentManagementService{
       ]);
   }
 
-  public function Custom($method, $documentInformation)
-  {
-    return $this->ApiCall($method, $documentInformation);
-  }
 }

--- a/src/Brightree/Services/DocumentManagementService.php
+++ b/src/Brightree/Services/DocumentManagementService.php
@@ -7,7 +7,6 @@ class DocumentManagementService{
   use \Brightree\Traits\ApiTrait;
   use \Brightree\Traits\CustomTrait;
 
-
   public function __construct($params) {
     $this->params = $params;
     $this->wsdl_path = "https://webservices.brightree.net/v0100-1910/DocumentationService/DocumentManagementService.svc?singleWsdl";
@@ -47,5 +46,4 @@ class DocumentManagementService{
       'FileContents' => $FileContents
       ]);
   }
-
 }

--- a/src/Brightree/Services/DocumentationService.php
+++ b/src/Brightree/Services/DocumentationService.php
@@ -7,7 +7,6 @@ class DocumentationService{
   use \Brightree\Traits\ApiTrait;
   use \Brightree\Traits\CustomTrait;
 
-
   public function __construct($params) {
     $this->params = $params;
     $this->wsdl_path = "https://webservices.brightree.net/v0100-2001/DocumentationService/DocumentationService.svc?singleWsdl";

--- a/src/Brightree/Services/DocumentationService.php
+++ b/src/Brightree/Services/DocumentationService.php
@@ -10,4 +10,9 @@ class DocumentationService{
     $this->params = $params;
     $this->wsdl_path = "https://webservices.brightree.net/v0100-2001/DocumentationService/DocumentationService.svc?singleWsdl";
   }
+
+  public function Custom($method, $documentationInformation)
+  {
+    return $this->ApiCall($method, $documentationInformation);
+  }
 }

--- a/src/Brightree/Services/DocumentationService.php
+++ b/src/Brightree/Services/DocumentationService.php
@@ -5,14 +5,11 @@ namespace Brightree\Services;
 class DocumentationService{
 
   use \Brightree\Traits\ApiTrait;
+  use \Brightree\Traits\CustomTrait;
+
 
   public function __construct($params) {
     $this->params = $params;
     $this->wsdl_path = "https://webservices.brightree.net/v0100-2001/DocumentationService/DocumentationService.svc?singleWsdl";
-  }
-
-  public function Custom($method, $documentationInformation)
-  {
-    return $this->ApiCall($method, $documentationInformation);
   }
 }

--- a/src/Brightree/Services/InsuranceService.php
+++ b/src/Brightree/Services/InsuranceService.php
@@ -10,4 +10,9 @@ class InsuranceService {
     $this->params = $params;
     $this->wsdl_path = "https://webservices.brightree.net/v0100-2006/OrderEntryService/InsuranceService.svc?singleWsdl";
   }
+
+  public function Custom($method, $insuranceInformation)
+  {
+    return $this->ApiCall($method, $insuranceInformation);
+  }
 }

--- a/src/Brightree/Services/InsuranceService.php
+++ b/src/Brightree/Services/InsuranceService.php
@@ -5,14 +5,13 @@ namespace Brightree\Services;
 class InsuranceService {
 
   use \Brightree\Traits\ApiTrait;
+  use \Brightree\Traits\CustomTrait;
+
 
   public function __construct($params) {
     $this->params = $params;
     $this->wsdl_path = "https://webservices.brightree.net/v0100-2006/OrderEntryService/InsuranceService.svc?singleWsdl";
   }
 
-  public function Custom($method, $insuranceInformation)
-  {
-    return $this->ApiCall($method, $insuranceInformation);
-  }
+
 }

--- a/src/Brightree/Services/InsuranceService.php
+++ b/src/Brightree/Services/InsuranceService.php
@@ -7,11 +7,8 @@ class InsuranceService {
   use \Brightree\Traits\ApiTrait;
   use \Brightree\Traits\CustomTrait;
 
-
   public function __construct($params) {
     $this->params = $params;
     $this->wsdl_path = "https://webservices.brightree.net/v0100-2006/OrderEntryService/InsuranceService.svc?singleWsdl";
   }
-
-
 }

--- a/src/Brightree/Services/InventoryService.php
+++ b/src/Brightree/Services/InventoryService.php
@@ -10,4 +10,9 @@ class InventoryService {
     $this->params = $params;
     $this->wsdl_path = "https://webservices.brightree.net/v0100-2006/InventoryService/InventoryService.svc?singleWsdl";
   }
+
+  public function Custom($method, $inventoryInformation)
+  {
+    return $this->ApiCall($method, $inventoryInformation);
+  }
 }

--- a/src/Brightree/Services/InventoryService.php
+++ b/src/Brightree/Services/InventoryService.php
@@ -5,14 +5,11 @@ namespace Brightree\Services;
 class InventoryService {
 
   use \Brightree\Traits\ApiTrait;
+  use \Brightree\Traits\CustomTrait;
 
   public function __construct($params) {
     $this->params = $params;
     $this->wsdl_path = "https://webservices.brightree.net/v0100-2006/InventoryService/InventoryService.svc?singleWsdl";
   }
 
-  public function Custom($method, $inventoryInformation)
-  {
-    return $this->ApiCall($method, $inventoryInformation);
-  }
 }

--- a/src/Brightree/Services/InventoryService.php
+++ b/src/Brightree/Services/InventoryService.php
@@ -11,5 +11,4 @@ class InventoryService {
     $this->params = $params;
     $this->wsdl_path = "https://webservices.brightree.net/v0100-2006/InventoryService/InventoryService.svc?singleWsdl";
   }
-
 }

--- a/src/Brightree/Services/PatientBillingService.php
+++ b/src/Brightree/Services/PatientBillingService.php
@@ -5,14 +5,12 @@ namespace Brightree\Services;
 class PatientBillingService {
 
   use \Brightree\Traits\ApiTrait;
+  use \Brightree\Traits\CustomTrait;
+
 
   public function __construct($params) {
     $this->params = $params;
     $this->wsdl_path = "https://webservices.brightree.net/v0100-1909/InvoiceService/InvoiceService.svc?singleWsdl";
   }
 
-  public function Custom($method, $invoiceInformation)
-  {
-    return $this->ApiCall($method, $invoiceInformation);
-  }
 }

--- a/src/Brightree/Services/PatientBillingService.php
+++ b/src/Brightree/Services/PatientBillingService.php
@@ -7,10 +7,8 @@ class PatientBillingService {
   use \Brightree\Traits\ApiTrait;
   use \Brightree\Traits\CustomTrait;
 
-
   public function __construct($params) {
     $this->params = $params;
     $this->wsdl_path = "https://webservices.brightree.net/v0100-1909/InvoiceService/InvoiceService.svc?singleWsdl";
   }
-
 }

--- a/src/Brightree/Services/PatientBillingService.php
+++ b/src/Brightree/Services/PatientBillingService.php
@@ -10,4 +10,9 @@ class PatientBillingService {
     $this->params = $params;
     $this->wsdl_path = "https://webservices.brightree.net/v0100-1909/InvoiceService/InvoiceService.svc?singleWsdl";
   }
+
+  public function Custom($method, $invoiceInformation)
+  {
+    return $this->ApiCall($method, $invoiceInformation);
+  }
 }

--- a/src/Brightree/Services/PatientService.php
+++ b/src/Brightree/Services/PatientService.php
@@ -9,6 +9,8 @@ use Brightree\Patient\PatientPayor;
 class PatientService {
 
   use \Brightree\Traits\ApiTrait;
+  use \Brightree\Traits\CustomTrait;
+
 
   public function __construct($params) {
     $this->params = $params;
@@ -61,7 +63,4 @@ class PatientService {
     return $patient->PatientFetchByBrightreeIDResult->Items->Patient->PatientInsuranceInfo->Payors->PatientPayorInfo;
   }
 
-  public function Custom($Method, $PatientInformation) {
-    return $this->ApiCall($Method, $PatientInformation);
-  }
 }

--- a/src/Brightree/Services/PatientService.php
+++ b/src/Brightree/Services/PatientService.php
@@ -2,15 +2,12 @@
 
 namespace Brightree\Services;
 
-use Brightree\OrderEntryService;
 use Brightree\Patient\Patient;
-use Brightree\Patient\PatientPayor;
 
 class PatientService {
 
   use \Brightree\Traits\ApiTrait;
   use \Brightree\Traits\CustomTrait;
-
 
   public function __construct($params) {
     $this->params = $params;
@@ -62,5 +59,4 @@ class PatientService {
     $patient = $this->ApiCall('PatientFetchbyBrightreeID', ['BrightreeID' => $BrightreeID]);
     return $patient->PatientFetchByBrightreeIDResult->Items->Patient->PatientInsuranceInfo->Payors->PatientPayorInfo;
   }
-
 }

--- a/src/Brightree/Services/PatientService.php
+++ b/src/Brightree/Services/PatientService.php
@@ -60,4 +60,8 @@ class PatientService {
     $patient = $this->ApiCall('PatientFetchbyBrightreeID', ['BrightreeID' => $BrightreeID]);
     return $patient->PatientFetchByBrightreeIDResult->Items->Patient->PatientInsuranceInfo->Payors->PatientPayorInfo;
   }
+
+  public function Custom($Method, $PatientInformation) {
+    return $this->ApiCall($Method, $PatientInformation);
+  }
 }

--- a/src/Brightree/Services/PickupExchangeService.php
+++ b/src/Brightree/Services/PickupExchangeService.php
@@ -10,4 +10,9 @@ class PickupExchangeService {
     $this->params = $params;
     $this->wsdl_path = "https://webservices.brightree.net/v0100-2007/OrderEntryService/PickupExchangeService.svc?singleWsdl";
   }
+
+  public function Custom($method, $pickupExchangeInformation)
+  {
+    return $this->ApiCall($method, $pickupExchangeInformation);
+  }
 }

--- a/src/Brightree/Services/PickupExchangeService.php
+++ b/src/Brightree/Services/PickupExchangeService.php
@@ -7,10 +7,8 @@ class PickupExchangeService {
   use \Brightree\Traits\ApiTrait;
   use \Brightree\Traits\CustomTrait;
 
-
   public function __construct($params) {
     $this->params = $params;
     $this->wsdl_path = "https://webservices.brightree.net/v0100-2007/OrderEntryService/PickupExchangeService.svc?singleWsdl";
   }
-
 }

--- a/src/Brightree/Services/PickupExchangeService.php
+++ b/src/Brightree/Services/PickupExchangeService.php
@@ -5,14 +5,12 @@ namespace Brightree\Services;
 class PickupExchangeService {
 
   use \Brightree\Traits\ApiTrait;
+  use \Brightree\Traits\CustomTrait;
+
 
   public function __construct($params) {
     $this->params = $params;
     $this->wsdl_path = "https://webservices.brightree.net/v0100-2007/OrderEntryService/PickupExchangeService.svc?singleWsdl";
   }
 
-  public function Custom($method, $pickupExchangeInformation)
-  {
-    return $this->ApiCall($method, $pickupExchangeInformation);
-  }
 }

--- a/src/Brightree/Services/PricingService.php
+++ b/src/Brightree/Services/PricingService.php
@@ -7,10 +7,8 @@ class PricingService {
   use \Brightree\Traits\ApiTrait;
   use \Brightree\Traits\CustomTrait;
 
-
   public function __construct($params) {
     $this->params = $params;
     $this->wsdl_path = "https://webservices.brightree.net/v0100-1908/InventoryService/PricingService.svc?singleWsdl";
   }
-
 }

--- a/src/Brightree/Services/PricingService.php
+++ b/src/Brightree/Services/PricingService.php
@@ -10,4 +10,9 @@ class PricingService {
     $this->params = $params;
     $this->wsdl_path = "https://webservices.brightree.net/v0100-1908/InventoryService/PricingService.svc?singleWsdl";
   }
+
+  public function Custom($method, $pricingInformation)
+  {
+    return $this->ApiCall($method, $pricingInformation);
+  }
 }

--- a/src/Brightree/Services/PricingService.php
+++ b/src/Brightree/Services/PricingService.php
@@ -5,14 +5,12 @@ namespace Brightree\Services;
 class PricingService {
 
   use \Brightree\Traits\ApiTrait;
+  use \Brightree\Traits\CustomTrait;
+
 
   public function __construct($params) {
     $this->params = $params;
     $this->wsdl_path = "https://webservices.brightree.net/v0100-1908/InventoryService/PricingService.svc?singleWsdl";
   }
 
-  public function Custom($method, $pricingInformation)
-  {
-    return $this->ApiCall($method, $pricingInformation);
-  }
 }

--- a/src/Brightree/Services/ReferenceDataService.php
+++ b/src/Brightree/Services/ReferenceDataService.php
@@ -7,12 +7,10 @@ class ReferenceDataService {
   use \Brightree\Traits\ApiTrait;
   use \Brightree\Traits\CustomTrait;
 
-
   private $params;
   private $wsdl_path = "https://webservices.brightree.net/v0100-1904/ReferenceDataService/ReferenceDataService.svc?singleWsdl";
 
   function __construct($params) {
     $this->params = $params;
   }
-
 }

--- a/src/Brightree/Services/ReferenceDataService.php
+++ b/src/Brightree/Services/ReferenceDataService.php
@@ -12,4 +12,9 @@ class ReferenceDataService {
   function __construct($params) {
     $this->params = $params;
   }
+
+  public function Custom($method, $referenceInformation)
+  {
+    return $this->ApiCall($method, $referenceInformation);
+  }
 }

--- a/src/Brightree/Services/ReferenceDataService.php
+++ b/src/Brightree/Services/ReferenceDataService.php
@@ -5,6 +5,8 @@ namespace Brightree\Services;
 class ReferenceDataService {
 
   use \Brightree\Traits\ApiTrait;
+  use \Brightree\Traits\CustomTrait;
+
 
   private $params;
   private $wsdl_path = "https://webservices.brightree.net/v0100-1904/ReferenceDataService/ReferenceDataService.svc?singleWsdl";
@@ -13,8 +15,4 @@ class ReferenceDataService {
     $this->params = $params;
   }
 
-  public function Custom($method, $referenceInformation)
-  {
-    return $this->ApiCall($method, $referenceInformation);
-  }
 }

--- a/src/Brightree/Services/SalesOrderService.php
+++ b/src/Brightree/Services/SalesOrderService.php
@@ -5,6 +5,8 @@ namespace Brightree\Services;
 class SalesOrderService {
 
   use \Brightree\Traits\ApiTrait;
+  use \Brightree\Traits\CustomTrait;
+
 
   public function __construct($params) {
     $this->params = $params;
@@ -61,8 +63,4 @@ class SalesOrderService {
     ]);
   }
 
-  public function Custom($method, $salesOrderInformation)
-  {
-    return $this->ApiCall($method, $salesOrderInformation);
-  }
 }

--- a/src/Brightree/Services/SalesOrderService.php
+++ b/src/Brightree/Services/SalesOrderService.php
@@ -7,7 +7,6 @@ class SalesOrderService {
   use \Brightree\Traits\ApiTrait;
   use \Brightree\Traits\CustomTrait;
 
-
   public function __construct($params) {
     $this->params = $params;
     $this->wsdl_path = "https://webservices.brightree.net/v0100-2005/OrderEntryService/SalesOrderService.svc?singleWsdl";
@@ -62,5 +61,4 @@ class SalesOrderService {
       'NewWIPStateID' => $NewWIPStateID
     ]);
   }
-
 }

--- a/src/Brightree/Services/SalesOrderService.php
+++ b/src/Brightree/Services/SalesOrderService.php
@@ -60,4 +60,9 @@ class SalesOrderService {
       'NewWIPStateID' => $NewWIPStateID
     ]);
   }
+
+  public function Custom($method, $salesOrderInformation)
+  {
+    return $this->ApiCall($method, $salesOrderInformation);
+  }
 }

--- a/src/Brightree/Services/SecurityService.php
+++ b/src/Brightree/Services/SecurityService.php
@@ -10,4 +10,9 @@ class SecurityService {
     $this->params = $params;
     $this->wsdl_path = "https://webservices.brightree.net/v0100-1906/SecurityService/UserSecurityService.svc?singleWsdl";
   }
+
+  public function Custom($method, $securityInformation)
+  {
+    return $this->ApiCall($method, $securityInformation);
+  }
 }

--- a/src/Brightree/Services/SecurityService.php
+++ b/src/Brightree/Services/SecurityService.php
@@ -11,5 +11,4 @@ class SecurityService {
     $this->params = $params;
     $this->wsdl_path = "https://webservices.brightree.net/v0100-1906/SecurityService/UserSecurityService.svc?singleWsdl";
   }
-  
 }

--- a/src/Brightree/Services/SecurityService.php
+++ b/src/Brightree/Services/SecurityService.php
@@ -5,14 +5,11 @@ namespace Brightree\Services;
 class SecurityService {
 
   use \Brightree\Traits\ApiTrait;
+  use \Brightree\Traits\CustomTrait;
 
   public function __construct($params) {
     $this->params = $params;
     $this->wsdl_path = "https://webservices.brightree.net/v0100-1906/SecurityService/UserSecurityService.svc?singleWsdl";
   }
-
-  public function Custom($method, $securityInformation)
-  {
-    return $this->ApiCall($method, $securityInformation);
-  }
+  
 }

--- a/src/Brightree/Traits/CustomTrait.php
+++ b/src/Brightree/Traits/CustomTrait.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Brightree\Traits;
+
+trait CustomTrait {
+    use \Brightree\Traits\ApiTrait;
+
+    public function Custom($service, $object)
+    {
+        return $this->ApiCall($service, $object);
+    }
+}


### PR DESCRIPTION
I added a trait that someone can use if you haven't defined a call or they want to use it different.  Kind of a "Catch All".

$service = Brightree->PatientService();
$service->Custom('PatientFetchByBrightreeID', ['BrightreeID' => 32456]);

Each service has the trait added.  It was prettier than coding a "custom" function in to each class with more descriptive variables.