### PR TITLE
Implement patient search function on the patient service

### DIFF
--- a/src/Brightree/Services/PatientService.php
+++ b/src/Brightree/Services/PatientService.php
@@ -59,4 +59,8 @@ class PatientService {
     $patient = $this->ApiCall('PatientFetchbyBrightreeID', ['BrightreeID' => $BrightreeID]);
     return $patient->PatientFetchByBrightreeIDResult->Items->Patient->PatientInsuranceInfo->Payors->PatientPayorInfo;
   }
+
+  public function PatientSearch($PatientSearchRequest) {
+    return $this->ApiCall('PatientSearch', $PatientSearchRequest);
+  }
 }


### PR DESCRIPTION
The PR implements the PatientSearch function on the Patient Service.

```
$bt = new BrightreeClient(["username" => "", "password" => ""]);

$search = [
    "searchRequest" => ["FirstName" => "Jane", "LastName" => "Doe"],
    "sortRequest" => [],
    "pageSize" => 1,
    "page" => 1
];

$response = $bt->PatientService()->PatientSearch($search);
```

Closes #14 